### PR TITLE
Refactor Path Handling in Benchmark Scripts

### DIFF
--- a/benchmark/analysis/all_subplots.py
+++ b/benchmark/analysis/all_subplots.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import seaborn as sns
 import matplotlib.pyplot as plt
-from auxiliary.turbopath import turbopath
+from pathlib import Path
 
 # List of CSV files
 csv_list = [
@@ -85,7 +85,7 @@ for i, condition in enumerate(unique_conditions):
 
 # Save the entire figure after all subplots have been created
 plt.tight_layout()
-file_name = turbopath(__file__).parent + "/boxplot_times"
+file_name = str(Path(__file__).parent / "boxplot_times")
 
 # Save with separate SVG formatter to include colors
 fig.savefig(file_name + ".png", format="png", bbox_inches="tight")

--- a/benchmark/analysis/individual_plots.py
+++ b/benchmark/analysis/individual_plots.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import seaborn as sns
 import matplotlib.pyplot as plt
-from auxiliary.turbopath import turbopath
+from pathlib import Path
 
 # List of CSV files
 csv_list = [
@@ -86,7 +86,7 @@ for i, condition in enumerate(unique_conditions):
     # Save each subplot individually
 
     file_name = f"{condition.replace(' ', '_').lower()}_comparison.png"
-    file_name = turbopath(__file__).parent + "/" + file_name
+    file_name = str(Path(__file__).parent / file_name)
     plt.savefig(file_name, bbox_inches="tight")
     plt.close()  # Close the current figure to release resources
 

--- a/benchmark/modules_speedtest.py
+++ b/benchmark/modules_speedtest.py
@@ -1,5 +1,5 @@
 from auxiliary.io import read_image
-from auxiliary.turbopath import turbopath
+from pathlib import Path
 import os
 import cpuinfo
 import json
@@ -22,14 +22,14 @@ import csv
 
 import pandas as pd
 
-directory = turbopath(__file__).parent.parent
+directory = Path(__file__).parent.parent
 
-ref_masks = read_image(directory + "/examples/spine_seg/semantic/ref.nii.gz")
-pred_masks = read_image(directory + "/examples/spine_seg/semantic/pred.nii.gz")
+ref_masks = read_image(str(directory / "examples" / "spine_seg" / "semantic" / "ref.nii.gz"))
+pred_masks = read_image(str(directory / "examples" / "spine_seg" / "semantic" / "pred.nii.gz"))
 
 platform_name = "ryzen9_new"
 
-csv_out = directory + "/benchmark/results/" + platform_name + "/performance_"
+csv_out = str(directory / "benchmark" / "results" / platform_name / "performance_")
 
 
 def evaluate_nparray(array, return_as_dict=False, verbose=False):
@@ -167,7 +167,7 @@ if __name__ == "__main__":
     # CPU information
     cpu_dict = cpuinfo.get_cpu_info()
 
-    cpu_json_path = directory + "/benchmark/results/" + platform_name + "/platform.json"
+    cpu_json_path = directory / "benchmark" / "results" / platform_name / "platform.json"
     print("cpu_json_path:", cpu_json_path.parent)
     # os.makedirs(cpu_json_path.parent, exist_ok=True)
 
@@ -191,7 +191,7 @@ if __name__ == "__main__":
         print()
         print()
         print(sample_name)
-        csv_name = csv_out + sample_name + ".csv"
+        csv_name = str(Path(csv_out) / f"{sample_name}.csv")
         with open(csv_name, "w", newline="") as csvfile:
             spamwriter = csv.writer(
                 csvfile, delimiter=";", quotechar="|", quoting=csv.QUOTE_MINIMAL

--- a/examples/example_spine_statistics.py
+++ b/examples/example_spine_statistics.py
@@ -1,5 +1,5 @@
 from auxiliary.io import read_image
-from auxiliary.turbopath import turbopath
+from pathlib import Path
 
 from panoptica import (
     Panoptica_Evaluator,
@@ -28,10 +28,10 @@ def main(parallel_opt: str = "future"):  # none, pool, joblib, future
     except:
         pass
 
-    directory = turbopath(__file__).parent
+    directory = Path(__file__).parent
 
-    reference_mask = read_image(directory + "/spine_seg/matched_instance/ref.nii.gz")
-    prediction_mask = read_image(directory + "/spine_seg/matched_instance/pred.nii.gz")
+    reference_mask = read_image(str(directory / "spine_seg" / "matched_instance" / "ref.nii.gz"))
+    prediction_mask = read_image(str(directory / "spine_seg" / "matched_instance" / "pred.nii.gz"))
 
     evaluator = Panoptica_Aggregator(
         Panoptica_Evaluator.load_from_config("panoptica_evaluator_unmatched_instance"),


### PR DESCRIPTION
This pull request addresses issue #217 by refactoring the script files in the benchmark analysis folder to use `pathlib.Path` instead of a deprecated custom path handling method (`turbopath`). 

Changes include:
- Replacing imports of `turbopath` with `pathlib.Path`
- Updating path construction for saving and loading files to ensure compatibility and readability.

These modifications improve the code's maintainability and streamline file handling in the benchmarking scripts.

---

> This pull request was co-created with Cosine Genie

Original Task: [panoptica/dvd80ylys6ia](https://cosine.sh/crkc63xk8fkl/panoptica/task/dvd80ylys6ia)
Author: Soumya Snigdha Kundu
